### PR TITLE
remove empty li nodes from the end/beginning when pasting

### DIFF
--- a/src/editor/insertFragment.test.tsx
+++ b/src/editor/insertFragment.test.tsx
@@ -199,6 +199,62 @@ describe('insert list items', () => {
       </editor>
     )
   });
+
+  it('collapses empty list items at the beginning on paste', () => {
+    expectEditor(
+      <editor>
+        <ul>
+          <li><p>foo<cursor/></p></li>
+        </ul>
+      </editor>,
+
+      editor => {
+        insertFragment(editor)(
+          <fragment>
+            <ul>
+              <li><p><stext /></p></li>
+              <li><p>bar</p></li>
+            </ul>
+          </fragment> as unknown as Node[]
+        );
+      },
+
+      <editor>
+        <ul>
+          <li><p>foo</p></li>
+          <li><p>bar<cursor/></p></li>
+        </ul>
+      </editor>
+    )
+  });
+
+  it('collapses empty list items at the end on paste', () => {
+    expectEditor(
+      <editor>
+        <ul>
+          <li><p>foo<cursor/></p></li>
+        </ul>
+      </editor>,
+
+      editor => {
+        insertFragment(editor)(
+          <fragment>
+            <ul>
+              <li><p>bar</p></li>
+              <li><p><stext /></p></li>
+            </ul>
+          </fragment> as unknown as Node[]
+        );
+      },
+
+      <editor>
+        <ul>
+          <li><p>foo</p></li>
+          <li><p>bar<cursor/></p></li>
+        </ul>
+      </editor>
+    )
+  });
 });
 
 describe('insert links', () => {

--- a/src/editor/insertFragment.ts
+++ b/src/editor/insertFragment.ts
@@ -1,4 +1,5 @@
 import { Editor, Element, Node, Range, Text, Transforms } from 'slate';
+import _ from 'lodash';
 
 import { bug } from '../util/bug';
 
@@ -66,6 +67,22 @@ export const insertFragment = (editor: Editor) => {
     if (lowest.type === 'ul') {
       const inListItemResult = inListItem(editor);
       if (inListItemResult) {
+        // Strip off any empty list items on either end.
+        // These end up in the tree that Slate gives us if the selection
+        // starts or ends with a newline.
+        if (_.isEqual(lowest.children[0], {
+          type: 'li',
+          children: [{ type: 'p', children: [{ text: '' }]}]
+        })) {
+          lowest.children.shift();
+        }
+        if (_.isEqual(lowest.children[lowest.children.length-1], {
+          type: 'li',
+          children: [{ type: 'p', children: [{ text: '' }]}]
+        })) {
+          lowest.children.pop();
+        }
+
         insertNodes(
           editor,
           lowest.children,


### PR DESCRIPTION
When a copied/cut list item selection includes a newline at the beginning or end, the current paste behavior is to insert an empty list item before or after the pasted item (depending on where the newline is). A more intuitive experience would be to to only insert the non-empty list item as a new item, without the empty item. This PR implements that behavior by checking for empty `li`s at the beginning or end of the list of nodes being inserted, and removing them before the insertion is performed.